### PR TITLE
Add probability std loss

### DIFF
--- a/pitch_detection/train.py
+++ b/pitch_detection/train.py
@@ -9,7 +9,7 @@ from torch.utils.data import DataLoader
 
 from pitch_detection import train_initial_weights
 from pitch_detection.configuration import Configuration
-from pitch_detection.pitch_autoencoder import PitchAutoencoder
+from pitch_detection.pitch_autoencoder import PitchAutoencoder, distribution_std
 
 
 def sweep_run():
@@ -103,7 +103,7 @@ def train(cfg: Configuration):
             loss = (l1(y, x)
                     + cfg.lambda1 * model.synth.conv.weight.abs().mean()
                     + cfg.lambda2 * f.abs().mean()
-                    + cfg.lambda3 * f.std())
+                    + cfg.lambda3 * distribution_std(f))
 
             opt.zero_grad()
             loss.backward()


### PR DESCRIPTION
## Summary
- add `distribution_std` to compute standard deviation with normalized magnitudes
- use new loss in training instead of raw `f.std()`

## Testing
- `python -m py_compile pitch_detection/pitch_autoencoder.py pitch_detection/train.py`

------
https://chatgpt.com/codex/tasks/task_e_684859b0ebcc83259e123b041112ad47