### PR TITLE
Add toy spectra generator

### DIFF
--- a/scripts/generate_toy_spectra.py
+++ b/scripts/generate_toy_spectra.py
@@ -1,0 +1,20 @@
+import torch
+
+# configuration
+num_samples = 1000  # number of samples
+num_frames = 200    # time frames per sample
+num_bins = 256      # frequency bins
+f_delta = 30        # f1 - f0 distance
+magnitude = 100     # value at f0 and f1
+save_file = "toy_spectra.pt"
+
+
+if __name__ == "__main__":
+    specs = torch.zeros(num_samples, num_bins, num_frames)
+    for i in range(num_samples):
+        f0 = torch.randint(0, num_bins - f_delta, (1,)).item()
+        f1 = f0 + f_delta
+        specs[i, f0] = magnitude
+        specs[i, f1] = magnitude
+    torch.save(specs, save_file)
+    print(f"saved {num_samples} samples to {save_file}")


### PR DESCRIPTION
## Summary
- generate artificial spectrogram data for pitch detection experiments

## Testing
- `python -m py_compile scripts/generate_toy_spectra.py`
- `python scripts/generate_toy_spectra.py`

------
https://chatgpt.com/codex/tasks/task_e_684af0c4a5b8832591891ddbfe6debb4