### PR TITLE
Add SynthNet v2 with 2D kernels

### DIFF
--- a/docker/pitch_detection/single_run_input.json
+++ b/docker/pitch_detection/single_run_input.json
@@ -2,7 +2,8 @@
   "input": {
     "batch": 128,
     "epochs": 10,
-    "kernel_len": 128,
+    "kernel_f_len": 128,
+    "kernel_t_len": 1,
     "lambda1": 1,
     "lambda2": 0.001,
     "lambda3": 0.0001,

--- a/pitch_detection/configuration.py
+++ b/pitch_detection/configuration.py
@@ -10,7 +10,8 @@ class Configuration:
     out_ch: int = 32
     lr: float = 1e-3
     lr_decay: float = 0.98
-    kernel_len: int = 128
+    kernel_f_len: int = 128
+    kernel_t_len: int = 1
     kernel_random: bool = False
     kernel_value: float = 0.1
     force_f0: bool = False

--- a/pitch_detection/pitch_autoencoder.py
+++ b/pitch_detection/pitch_autoencoder.py
@@ -6,9 +6,10 @@ from pitch_detection.configuration import Configuration
 from pitch_detection.pitch_det_net_v1 import PitchDetNet as PitchDetNetV1
 from pitch_detection.pitch_det_net_v2 import PitchDetNet as PitchDetNetV2
 from pitch_detection.synth_net_v1 import SynthNet as SynthNetV1
+from pitch_detection.synth_net_v2 import SynthNet as SynthNetV2
 
 _PITCH_DET_REGISTRY = {1: PitchDetNetV1, 2: PitchDetNetV2}
-_SYNTH_REGISTRY = {1: SynthNetV1}
+_SYNTH_REGISTRY = {1: SynthNetV1, 2: SynthNetV2}
 
 
 def get_pitch_det_model(version: str, cfg: Configuration) -> nn.Module:
@@ -26,9 +27,7 @@ def get_synth_model(version: str, cfg: Configuration) -> nn.Module:
         net_cls = _SYNTH_REGISTRY[v_num]
     except KeyError as e:
         raise ValueError(f"Unknown synth_net version {version}") from e
-    return net_cls(channels=cfg.out_ch, kernel_len=cfg.kernel_len,
-                   force_f0=cfg.force_f0, kernel_random=cfg.kernel_random,
-                   kernel_value=cfg.kernel_value)
+    return net_cls(cfg)
 
 
 class PitchAutoencoder(nn.Module):

--- a/pitch_detection/synth_net_v1.py
+++ b/pitch_detection/synth_net_v1.py
@@ -3,6 +3,8 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
+from pitch_detection.configuration import Configuration
+
 
 class SynthNet(nn.Module):
     """
@@ -11,19 +13,17 @@ class SynthNet(nn.Module):
     Fundamental weight is frozen to 1; overtones are constrained to (0,1).
     """
 
-    def __init__(self, channels: int = 32, kernel_len: int = 128, force_f0: bool = False, kernel_random: bool = False,
-                 kernel_value: float = 0.1) -> None:
+    def __init__(self, cfg: Configuration) -> None:
         super().__init__()
-        self.channels = channels
-        self.kernel_len = kernel_len
+        self.channels = cfg.out_ch
+        self.kernel_f_len = cfg.kernel_f_len
         # positive convolution kernels as raw parameters
-
-        inv_kernel_value = np.log(np.exp(kernel_value) - 1)
-        if kernel_random:
-            self.kernel = nn.Parameter(inv_kernel_value - torch.rand(channels, 1, kernel_len))
+        inv_kernel_value = np.log(np.exp(cfg.kernel_value) - 1)
+        if cfg.kernel_random:
+            self.kernel = nn.Parameter(inv_kernel_value - torch.rand(self.channels, 1, self.kernel_f_len))
         else:
-            self.kernel = nn.Parameter(torch.ones(channels, 1, kernel_len) * inv_kernel_value)
-        self.force_f0 = force_f0
+            self.kernel = nn.Parameter(torch.ones(self.channels, 1, self.kernel_f_len) * inv_kernel_value)
+        self.force_f0 = cfg.force_f0
 
     def forward(self, x):  # (B,32,F,T)
         B, C, F_, T = x.shape
@@ -34,7 +34,7 @@ class SynthNet(nn.Module):
 
         # (B, C, F, T) -> (B, T, C, F) -> (B*T, C, F)
         x_ft = x.permute(0, 3, 1, 2).contiguous().view(B * T, C, F_)
-        eff_kernel_len = self.kernel_len + (1 if self.force_f0 else 0)
+        eff_kernel_len = self.kernel_f_len + (1 if self.force_f0 else 0)
         x_ft = F.pad(x_ft, (eff_kernel_len - 1, 0))
 
         # use positive kernels via softplus transformation

--- a/pitch_detection/synth_net_v2.py
+++ b/pitch_detection/synth_net_v2.py
@@ -1,0 +1,46 @@
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from pitch_detection.configuration import Configuration
+
+
+class SynthNet(nn.Module):
+    """Depth-wise 2-D conv along frequency and time."""
+
+    def __init__(self, cfg: Configuration) -> None:
+        super().__init__()
+        self.channels = cfg.out_ch
+        self.kernel_f_len = cfg.kernel_f_len
+        self.kernel_t_len = cfg.kernel_t_len
+
+        inv_kernel_value = np.log(np.exp(cfg.kernel_value) - 1)
+        if cfg.kernel_random:
+            self.kernel = nn.Parameter(
+                inv_kernel_value
+                - torch.rand(self.channels, 1, self.kernel_f_len, self.kernel_t_len),
+            )
+        else:
+            self.kernel = nn.Parameter(
+                torch.ones(self.channels, 1, self.kernel_f_len, self.kernel_t_len)
+                * inv_kernel_value,
+            )
+        self.force_f0 = cfg.force_f0
+
+    def forward(self, x):  # (B,C,F,T)
+        B, C, F_, T = x.shape
+        eff_kernel_f_len = self.kernel_f_len + (1 if self.force_f0 else 0)
+        pad_t_left = self.kernel_t_len // 2
+        pad_t_right = self.kernel_t_len - 1 - pad_t_left
+        x = F.pad(x, (pad_t_left, pad_t_right, eff_kernel_f_len - 1, 0))
+
+        weight = F.softplus(self.kernel)
+        if self.force_f0:
+            ones = torch.ones(C, 1, 1, self.kernel_t_len, device=x.device)
+            weight = torch.cat([ones, weight], dim=2)
+
+        weight = torch.flip(weight, dims=[-2])
+        y = F.conv2d(x, weight, groups=C)
+        y = y.mean(dim=1, keepdim=True)
+        return y  # (B,1,F,T)

--- a/scripts/sweep_pitch_detection.py
+++ b/scripts/sweep_pitch_detection.py
@@ -17,7 +17,8 @@ sweep_cfg = {
     "parameters": {
         "lr": {"value": 0.005},  # {"min": 1e-3, "max": 1e-1, "distribution": "log_uniform_values"},
         "lr_decay": {"values": [0.9]},
-        "kernel_len": {"values": [64, 128]},
+        "kernel_f_len": {"values": [64, 128]},
+        "kernel_t_len": {"value": 1},
         "lambda1": {"value": 0.0},  # entropy
         "lambda2": {"value": 0.0},  # L1 activity
         "lambda3": {"value": 0.0},  # Laplacian


### PR DESCRIPTION
## Summary
- add a new SynthNet implementation using 2‑D convolution kernels
- support frequency and time kernel lengths in configuration
- wire SynthNet v2 into `pitch_autoencoder`
- update sweep script and docker input for new parameters
- adjust SynthNet classes to use the configuration object directly

## Testing
- `python -m py_compile $(git ls-files '*.py' | tr '\n' ' ')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c29591af083259d7f2fc4ed482a53