### PR TITLE
Add string init_f0 modes

### DIFF
--- a/pitch_detection/configuration.py
+++ b/pitch_detection/configuration.py
@@ -15,7 +15,7 @@ class Configuration:
     kernel_random: bool = False
     kernel_value: float = 0.1
     force_f0: bool = False
-    init_f0: bool = False
+    init_f0: str = "none"  # options: "none", "point", "exponential"
     lambda1: float = 1.0  # entropy
     lambda2: float = 1e-3  # L1 activity
     lambda3: float = 1e-4  # Laplacian


### PR DESCRIPTION
## Summary
- change `init_f0` configuration from boolean to string
- implement exponential initializer for SynthNet kernels
- adjust exponential weights so channel 0 has no decay

## Testing
- `python3 -m py_compile pitch_detection/configuration.py pitch_detection/synth_net_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_6851420f07188325944a5effe60e4621