### PR TITLE
Add pitch_det_lr option

### DIFF
--- a/pitch_detection/configuration.py
+++ b/pitch_detection/configuration.py
@@ -9,6 +9,7 @@ class Configuration:
     base_ch: int = 16
     out_ch: int = 32
     lr: float = 1e-3
+    pitch_det_lr: float | None = None
     lr_decay: float = 0.98
     kernel_f_len: int = 128
     kernel_t_len: int = 1

--- a/pitch_detection/train.py
+++ b/pitch_detection/train.py
@@ -101,7 +101,15 @@ def train(cfg: Configuration):
     if cfg.initial_weights_file is not None:
         model.pitch_det_net.load_state_dict(torch.load(cfg.initial_weights_file, map_location=dev))
 
-    opt = torch.optim.AdamW(model.parameters(), lr=cfg.lr)
+    if cfg.pitch_det_lr is not None:
+        opt = torch.optim.AdamW(
+            [
+                {"params": model.synth.parameters(), "lr": cfg.lr},
+                {"params": model.pitch_det_net.parameters(), "lr": cfg.pitch_det_lr},
+            ]
+        )
+    else:
+        opt = torch.optim.AdamW(model.parameters(), lr=cfg.lr)
     sch = ExponentialLR(opt, gamma=cfg.lr_decay)
     l1 = torch.nn.L1Loss()
 


### PR DESCRIPTION
## Summary
- allow a separate learning rate for the pitch detection network
- adjust the trainer to use different rates when provided

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543a094dc083259e4420cb43ae0ec3