### PR TITLE
Remove unused params from pitch sweep

### DIFF
--- a/docker/pitch_detection/single_run_input.json
+++ b/docker/pitch_detection/single_run_input.json
@@ -6,12 +6,10 @@
     "kernel_t_len": 1,
     "lambda1": 1,
     "lambda2": 0.001,
-    "lambda3": 0.0001,
     "lr": 0.005,
     "lr_decay": 0.9,
     "base_ch": 16,
     "spec_file": "/runpod-volume/logspectrograms.pt",
-    "ckpt_dir": "/runpod-volume/checkpoints",
     "save_model": false
   }
 }

--- a/scripts/sweep_pitch_detection.py
+++ b/scripts/sweep_pitch_detection.py
@@ -21,7 +21,6 @@ sweep_cfg = {
         "kernel_t_len": {"value": 1},
         "lambda1": {"value": 0.0},  # entropy
         "lambda2": {"value": 0.0},  # L1 activity
-        "lambda3": {"value": 0.0},  # Laplacian
         "batch": {"value": 128},
         "epochs": {"value": 1},
         "base_ch": {"values": [4, 16]},


### PR DESCRIPTION
## Summary
- tidy up `sweep_pitch_detection.py` by removing the unused `lambda3`
- update `docker/pitch_detection/single_run_input.json` to match the actual Configuration dataclass

## Testing
- `python3 -m py_compile scripts/sweep_pitch_detection.py`
- `python3 - <<'PY'
import json
json.load(open('docker/pitch_detection/single_run_input.json'))
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68595a088378832590395ba5e3412ad2