### PR TITLE
Add Lagrange multiplier for entropy constraint

### DIFF
--- a/pitch_detection/configuration.py
+++ b/pitch_detection/configuration.py
@@ -17,8 +17,9 @@ class Configuration:
     kernel_value: float = 0.1
     force_f0: bool = False
     init_f0: str = "none"  # options: "none", "point", "exponential"
-    lambda1: float = 1.0  # compression goal weight
-    lambda2: float = 1e-3  # target compression rate
+    lambda1: float = 1e-3  # dual variable learning rate
+    lambda2: float = 0.6  # \u03b1 in constraint H(q) <= \u03b1 H(p)
+    lambda_init: float = 0.0  # initial dual variable value
     train_initial_weights: bool = True
     initial_weights_file: str = None
     save_model: bool = True

--- a/scripts/sweep_pitch_detection.py
+++ b/scripts/sweep_pitch_detection.py
@@ -18,8 +18,8 @@ sweep_cfg = {
         "lr": {"value": 0.001},
         "lr_decay": {"value": 1.0},
         "pitch_det_lr": {"value": 0.02},
-        "lambda1": {"min": 0.01, "max":0.5, "distribution": "log_uniform_values"},  # entropy goal strength
-        "lambda2": {"value": 0.2},  # entropy goal
+        "lambda1": {"value": 1e-3},
+        "lambda2": {"value": 0.6},
         "batch": {"value": 128},
         "epochs": {"value": 5},
         "base_ch": {"value": 16},


### PR DESCRIPTION
## Summary
- add dual variable initialization and learning rate to pitch-detection configuration
- enforce entropy ratio constraint using existing `lambda1`/`lambda2`
- update sweep config to use these parameters

## Testing
- `python -m py_compile pitch_detection/train.py pitch_detection/configuration.py scripts/sweep_pitch_detection.py`


------
https://chatgpt.com/codex/tasks/task_e_685aaf5a14d48325a09d9326097e3a21