### PR TITLE
Update code for Python 3.12

### DIFF
--- a/pitch_detection/channel_eval.py
+++ b/pitch_detection/channel_eval.py
@@ -54,13 +54,13 @@ class ChannelEvalConfig:
     wandb_project: str = "pitch-channel-eval"
 
     @classmethod
-    def from_dict(cls, data: Dict) -> "ChannelEvalConfig":
+    def from_dict(cls, data: dict) -> "ChannelEvalConfig":
         if "model_cfg" in data:
             data["model_cfg"] = Configuration(**data["model_cfg"])
         return cls(**data)
 
 
-def evaluate_channels(cfg: ChannelEvalConfig) -> Dict[str, List[float]]:
+def evaluate_channels(cfg: ChannelEvalConfig) -> dict[str, list[float]]:
     """Analyse pitch-detector channel activations per instrument."""
 
     wandb.login(key=os.getenv("WANDB_API_KEY"), anonymous="allow")
@@ -82,7 +82,7 @@ def evaluate_channels(cfg: ChannelEvalConfig) -> Dict[str, List[float]]:
 
     converter = LogSpectrogram(dev)
 
-    totals_by_instr: Dict[str, torch.Tensor] = defaultdict(
+    totals_by_instr: dict[str, torch.Tensor] = defaultdict(
         lambda: torch.zeros(cfg.model_cfg.out_ch, device=dev)
     )
     totals_all = torch.zeros(cfg.model_cfg.out_ch, device=dev)

--- a/unmixer/mix_creator.py
+++ b/unmixer/mix_creator.py
@@ -13,7 +13,7 @@ __all__ = [
 ]
 
 
-def create_room_configs() -> List[dict]:
+def create_room_configs() -> list[dict]:
     return [
         {"name": "small_absorptive", "dimensions": (5.0, 4.0, 3.0), "absorption": 0.6, "max_order": 3},
         {"name": "small_reflective", "dimensions": (5.0, 4.0, 3.0), "absorption": 0.1, "max_order": 3},
@@ -23,14 +23,14 @@ def create_room_configs() -> List[dict]:
     ]
 
 
-def _choose_dataset(file_lists: Dict[str, List[Path]]) -> str:
+def _choose_dataset(file_lists: dict[str, list[Path]]) -> str:
     names = list(file_lists.keys())
     counts = [len(file_lists[n]) for n in names]
     return random.choices(names, weights=counts, k=1)[0]
 
 
 def generate_mixes(
-    dataset_roots: Dict[str, Path],
+    dataset_roots: dict[str, Path],
     output_root: Path,
     *,
     num_mixes: int,


### PR DESCRIPTION
## Summary
- run `pyupgrade --py312-plus` to modernize type hints for Python 3.12
- update type hints in `channel_eval.py` and `mix_creator.py`

## Testing
- `pip install numpy soundfile`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e99afe7108325b9a3931b507c48d3