### PR TITLE
Add local-context MLP pitch classifier module

### DIFF
--- a/pitch_detection_supervised/local_context_mlp.py
+++ b/pitch_detection_supervised/local_context_mlp.py
@@ -1,0 +1,130 @@
+"""Lightweight local-context MLP for supervised pitch detection."""
+from __future__ import annotations
+
+import torch.nn.functional as F
+import torch
+from torch import Tensor, nn
+
+__all__ = ["LocalContextMLP"]
+
+
+class LocalContextMLP(nn.Module):
+    """Predict pitch class logits using local temporal context.
+
+    Args:
+        n_classes: Number of output pitch classes ``C``.
+        seq_len: Expected number of time steps ``T`` in the input sequence.
+        latent_dim: Dimensionality of the input latent features ``D``.
+        hidden_dim: Hidden dimensionality ``H`` of the time-distributed MLP.
+        kernel_size: Kernel size for the depthwise temporal convolution.
+        dropout: Dropout probability used inside the MLP head.
+
+    Input shape:
+        ``(batch, time, latent_dim)``.
+
+    Output shape:
+        ``(batch, time, n_classes)`` containing the logits for each class.
+    """
+
+    def __init__(
+        self,
+        *,
+        n_classes: int = 128,
+        seq_len: int = 75,
+        latent_dim: int = 128,
+        hidden_dim: int = 256,
+        kernel_size: int = 15,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        if kernel_size % 2 == 0:
+            raise ValueError(
+                "kernel_size must be odd to preserve sequence length with symmetric padding."
+            )
+        if latent_dim <= 0:
+            raise ValueError("latent_dim must be positive.")
+        if hidden_dim <= 0:
+            raise ValueError("hidden_dim must be positive.")
+        if n_classes <= 0:
+            raise ValueError("n_classes must be positive.")
+        if seq_len <= 0:
+            raise ValueError("seq_len must be positive.")
+        if not (0.0 <= dropout < 1.0):
+            raise ValueError("dropout must be in the interval [0, 1).")
+
+        self.n_classes = n_classes
+        self.seq_len = seq_len
+        self.latent_dim = latent_dim
+        self.hidden_dim = hidden_dim
+        self.kernel_size = kernel_size
+        self.dropout = dropout
+
+        padding = kernel_size // 2
+
+        self.temporal_conv = nn.Conv1d(
+            in_channels=latent_dim,
+            out_channels=latent_dim,
+            kernel_size=kernel_size,
+            stride=1,
+            padding=padding,
+            dilation=1,
+            groups=latent_dim,
+            bias=True,
+        )
+        self.temporal_activation = nn.GELU()
+
+        self.mlp_head = nn.Sequential(
+            nn.Linear(latent_dim, hidden_dim),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden_dim, n_classes),
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Run the local context MLP.
+
+        Args:
+            x: Input tensor of shape ``(batch, time, latent_dim)``.
+
+        Returns:
+            Logits tensor of shape ``(batch, time, n_classes)``.
+        """
+
+        if x.ndim != 3:
+            raise ValueError(
+                f"Expected input tensor with 3 dimensions (batch, time, latent_dim), got shape {tuple(x.shape)}."
+            )
+        batch_size, time_steps, feature_dim = x.shape
+        if time_steps != self.seq_len:
+            raise ValueError(
+                f"Expected time dimension T={self.seq_len}, but received T={time_steps}."
+            )
+        if feature_dim != self.latent_dim:
+            raise ValueError(
+                f"Expected feature dimension D={self.latent_dim}, but received D={feature_dim}."
+            )
+
+        # L2-normalize each time step independently across the latent dimension.
+        x = F.normalize(x, p=2.0, dim=-1, eps=1e-12)
+
+        # Depthwise temporal convolution over local context.
+        x = x.transpose(1, 2)  # (B, D, T)
+        x = self.temporal_conv(x)
+        x = self.temporal_activation(x)
+        x = x.transpose(1, 2)  # (B, T, D)
+
+        # Time-distributed MLP head operating on each time step independently.
+        logits = self.mlp_head(x)
+        if logits.shape != (batch_size, time_steps, self.n_classes):
+            raise RuntimeError(
+                "Unexpected logits shape after MLP head: "
+                f"expected {(batch_size, time_steps, self.n_classes)}, got {tuple(logits.shape)}."
+            )
+        return logits
+
+
+if __name__ == "__main__":
+    model = LocalContextMLP()
+    dummy_input = torch.randn(2, 75, 128)
+    output = model(dummy_input)
+    print(output.shape)


### PR DESCRIPTION
## Summary
- implement a LocalContextMLP module for predicting 128 pitch classes with configurable sequence and latent dimensions
- apply per-step L2 normalization followed by a depthwise temporal convolution to gather local context
- add a time-distributed MLP head with dropout and a usage example for quick validation

## Testing
- Not run (PyTorch is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfcee13e308325bce6b6a73c0d45d8