### PR TITLE
Extract evaluation utilities to dedicated module

### DIFF
--- a/pitch_detection_supervised/evaluate.py
+++ b/pitch_detection_supervised/evaluate.py
@@ -1,0 +1,138 @@
+import math
+from typing import Dict, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torch.nn import Module
+from torch.utils.data import DataLoader
+
+from .configuration import Config
+
+__all__ = [
+    "evaluate",
+    "soft_targets",
+    "_freq_to_space",
+    "_build_space_and_delta",
+    "_nearest_center_index",
+    "_compute_batch_metrics",
+]
+
+
+def _freq_to_space(freq_hz: Tensor, use_log: bool) -> Tensor:
+    if use_log:
+        return torch.log(freq_hz.clamp_min(1e-12))
+    return freq_hz
+
+
+def _build_space_and_delta(centers_hz_tensor: Tensor, use_log: bool) -> Tuple[Tensor, Tensor]:
+    space_centers = _freq_to_space(centers_hz_tensor, use_log)
+    if space_centers.numel() <= 1:
+        delta = torch.tensor(1.0, dtype=space_centers.dtype, device=space_centers.device)
+    else:
+        diffs = space_centers[1:] - space_centers[:-1]
+        delta = diffs.median()
+        if not torch.isfinite(delta):
+            delta = torch.tensor(1.0, dtype=space_centers.dtype, device=space_centers.device)
+    return space_centers, delta
+
+
+def _nearest_center_index(space_value: Tensor, space_centers: Tensor) -> Tensor:
+    diff = space_value.unsqueeze(-1) - space_centers
+    return torch.argmin(diff.abs(), dim=-1)
+
+
+def soft_targets(freq_hz: Tensor, centers_hz: Tensor, sigma_bins: float, use_log: bool) -> Tensor:
+    if sigma_bins <= 0:
+        raise ValueError("sigma_bins must be positive")
+
+    if freq_hz.ndim == 1:
+        freq_hz = freq_hz.unsqueeze(-1)
+    freq_hz = freq_hz.to(dtype=centers_hz.dtype, device=centers_hz.device)
+
+    space_centers, delta = _build_space_and_delta(centers_hz, use_log)
+    freq_space = _freq_to_space(freq_hz, use_log).unsqueeze(-1)
+    d = (freq_space - space_centers) / delta.clamp_min(1e-12)
+    weights = torch.exp(-0.5 * (d / sigma_bins) ** 2)
+    weights_sum = weights.sum(dim=-1, keepdim=True).clamp_min(1e-12)
+    return weights / weights_sum
+
+
+def _masked_average(value: Tensor, mask: Tensor) -> Tensor:
+    denom = mask.sum()
+    if denom <= 0:
+        return torch.zeros((), device=value.device, dtype=value.dtype)
+    return (value * mask).sum() / denom
+
+
+def _compute_batch_metrics(
+    logits: Tensor,
+    freq_hz: Tensor,
+    space_centers: Tensor,
+    within_bins: int,
+    use_log: bool,
+    mask: Tensor,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    pred_idx = logits.argmax(dim=-1)
+    freq_space = _freq_to_space(freq_hz, use_log)
+    target_idx = _nearest_center_index(freq_space, space_centers)
+    diff = (pred_idx - target_idx).abs().float()
+
+    top1 = (diff == 0).float()
+    within = (diff <= within_bins).float()
+
+    mask = mask.float()
+    top1_mean = _masked_average(top1, mask)
+    within_mean = _masked_average(within, mask)
+    mae_mean = _masked_average(diff, mask)
+
+    return top1_mean, within_mean, mae_mean
+
+
+@torch.no_grad()
+def evaluate(model: Module, data_loader: Optional[DataLoader], config: Config) -> Dict[str, float]:
+    if data_loader is None:
+        return {"loss": math.nan, "top1": math.nan, "within_k": math.nan, "mae_bins": math.nan}
+
+    model.eval()
+    device = next(model.parameters()).device
+
+    centers_hz = torch.tensor(config.centers_hz(), dtype=torch.float32, device=device)
+    space_centers, _ = _build_space_and_delta(centers_hz, config.log_bins)
+
+    total_loss = torch.zeros(1, device=device)
+    total_mask = torch.zeros(1, device=device)
+    total_top1 = torch.zeros(1, device=device)
+    total_within = torch.zeros(1, device=device)
+    total_mae = torch.zeros(1, device=device)
+
+    for batch in data_loader:
+        x = batch["x"].to(device, non_blocking=True)
+        freq = batch["freq_hz"].to(device, non_blocking=True)
+        mask = batch["valid_mask"].to(device, non_blocking=True).float()
+
+        logits = model(x)
+        target = soft_targets(freq, centers_hz, config.sigma_bins, config.log_bins)
+        log_q = F.log_softmax(logits, dim=-1)
+        frame_loss = -(target * log_q).sum(dim=-1)
+
+        mask_sum = mask.sum()
+        total_loss += (frame_loss * mask).sum()
+        total_mask += mask_sum
+
+        top1, within, mae = _compute_batch_metrics(
+            logits, freq, space_centers, config.within_bins, config.log_bins, mask
+        )
+
+        total_top1 += top1 * mask_sum
+        total_within += within * mask_sum
+        total_mae += mae * mask_sum
+
+    denom = total_mask.clamp_min(1.0)
+    metrics = {
+        "loss": (total_loss / denom).item(),
+        "top1": (total_top1 / denom).item(),
+        "within_k": (total_within / denom).item(),
+        "mae_bins": (total_mae / denom).item(),
+    }
+    return metrics

--- a/pitch_detection_supervised/make_loaders.py
+++ b/pitch_detection_supervised/make_loaders.py
@@ -1,0 +1,168 @@
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+import torch
+from torch import Tensor
+from torch.utils.data import DataLoader
+
+from .configuration import Config
+
+
+def pad_or_crop(x: Tensor, target_T: int) -> Tensor:
+    """Center-crop or pad the time dimension of *x* to *target_T* steps."""
+
+    if x.ndim == 0:
+        raise ValueError("pad_or_crop expects at least 1D tensor")
+
+    current_T = x.shape[0]
+    if current_T == target_T:
+        return x
+
+    if current_T > target_T:
+        start = (current_T - target_T) // 2
+        end = start + target_T
+        return x[start:end]
+
+    pad_total = target_T - current_T
+    pad_left = pad_total // 2
+    pad_right = pad_total - pad_left
+    pad_shape = list(x.shape)
+    pad_shape[0] = target_T
+    result = x.new_zeros(pad_shape)
+    result[pad_left : pad_left + current_T] = x
+    return result
+
+
+def _to_tensor(value: Any, dtype: torch.dtype = torch.float32) -> Tensor:
+    if isinstance(value, Tensor):
+        return value.to(dtype)
+    if isinstance(value, np.ndarray):
+        return torch.from_numpy(value).to(dtype)
+    if isinstance(value, (list, tuple)):
+        return torch.tensor(value, dtype=dtype)
+    if isinstance(value, (float, int)):
+        return torch.tensor(value, dtype=dtype)
+    raise TypeError(f"Unsupported type for tensor conversion: {type(value)!r}")
+
+
+def _normalize_time_steps(x: Tensor, eps: float = 1e-12) -> Tensor:
+    norm = torch.linalg.norm(x, dim=-1, keepdim=True)
+    norm = norm.clamp_min(eps)
+    return x / norm
+
+
+def _prepare_sample(sample: Any, config: Config) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+    seq_len = config.seq_len
+
+    if isinstance(sample, dict):
+        x = sample.get("x")
+        freq = sample.get("freq_hz")
+        valid = sample.get("valid_mask")
+    elif isinstance(sample, (list, tuple)):
+        if len(sample) < 2:
+            raise ValueError("Sample tuple must contain at least (x, freq_hz)")
+        x, freq = sample[0], sample[1]
+        valid = sample[2] if len(sample) > 2 else None
+    else:
+        raise TypeError("Unsupported sample type")
+
+    if x is None or freq is None:
+        raise ValueError("Sample must provide 'x' and 'freq_hz'")
+
+    x_tensor = _to_tensor(x, dtype=torch.float32)
+    if x_tensor.ndim == 1:
+        x_tensor = x_tensor.unsqueeze(-1)
+    x_tensor = pad_or_crop(x_tensor, seq_len)
+    if x_tensor.shape[-1] != config.latent_dim:
+        raise ValueError(
+            f"Sample latent dimension {x_tensor.shape[-1]} does not match config.latent_dim={config.latent_dim}"
+        )
+
+    freq_tensor = _to_tensor(freq, dtype=torch.float32)
+    if freq_tensor.ndim == 0:
+        freq_tensor = freq_tensor.repeat(seq_len)
+    elif freq_tensor.ndim == 1:
+        freq_tensor = pad_or_crop(freq_tensor.unsqueeze(-1), seq_len).squeeze(-1)
+    else:
+        freq_tensor = pad_or_crop(freq_tensor, seq_len)
+        freq_tensor = freq_tensor.squeeze(-1) if freq_tensor.ndim > 1 else freq_tensor
+    if freq_tensor.ndim != 1 or freq_tensor.shape[0] != seq_len:
+        freq_tensor = freq_tensor.reshape(seq_len)
+
+    if valid is None:
+        valid_tensor = torch.ones(seq_len, dtype=torch.float32)
+    else:
+        valid_tensor = _to_tensor(valid, dtype=torch.float32)
+        if valid_tensor.ndim == 0:
+            valid_tensor = valid_tensor.repeat(seq_len)
+        else:
+            valid_tensor = pad_or_crop(valid_tensor, seq_len)
+        valid_tensor = valid_tensor.float()
+    if valid_tensor.ndim != 1 or valid_tensor.shape[0] != seq_len:
+        valid_tensor = valid_tensor.reshape(seq_len)
+
+    return x_tensor, freq_tensor, valid_tensor
+
+
+def _build_collate_fn(config: Config) -> Callable[[Sequence[Any]], Dict[str, Tensor]]:
+    def collate(batch: Sequence[Any]) -> Dict[str, Tensor]:
+        xs: List[Tensor] = []
+        freqs: List[Tensor] = []
+        masks: List[Tensor] = []
+
+        for sample in batch:
+            x_tensor, freq_tensor, valid_tensor = _prepare_sample(sample, config)
+            xs.append(x_tensor)
+            freqs.append(freq_tensor)
+            masks.append(valid_tensor)
+
+        x_batch = torch.stack(xs, dim=0)
+        freq_batch = torch.stack(freqs, dim=0)
+        mask_batch = torch.stack(masks, dim=0).float()
+
+        x_batch = _normalize_time_steps(x_batch)
+
+        return {"x": x_batch, "freq_hz": freq_batch, "valid_mask": mask_batch}
+
+    return collate
+
+
+def make_loaders(
+    train_data: Optional[Iterable[Any]],
+    val_data: Optional[Iterable[Any]],
+    config: Config,
+) -> Tuple[Optional[DataLoader], Optional[DataLoader]]:
+    collate_fn = _build_collate_fn(config)
+
+    def _resolve_loader(data: Optional[Iterable[Any]], shuffle: bool) -> Optional[DataLoader]:
+        if data is None:
+            return None
+        if isinstance(data, DataLoader):
+            return data
+
+        if config.device is None:
+            pin_memory = torch.cuda.is_available()
+        else:
+            try:
+                device_type = torch.device(config.device).type
+                pin_memory = device_type == "cuda"
+            except (RuntimeError, ValueError):
+                pin_memory = False
+
+        return DataLoader(
+            data,
+            batch_size=config.batch_size,
+            shuffle=shuffle,
+            num_workers=config.num_workers,
+            pin_memory=pin_memory,
+            collate_fn=collate_fn,
+        )
+
+    return _resolve_loader(train_data, shuffle=True), _resolve_loader(val_data, shuffle=False)
+
+
+__all__ = [
+    "pad_or_crop",
+    "make_loaders",
+]
+

--- a/pitch_detection_supervised/train.py
+++ b/pitch_detection_supervised/train.py
@@ -1,0 +1,200 @@
+import copy
+import math
+import os
+import random
+from dataclasses import asdict
+from typing import Dict, Optional
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torch.nn import Module
+from torch.optim import AdamW
+from torch.utils.data import DataLoader
+
+from .configuration import Config
+from .evaluate import (
+    evaluate,
+    soft_targets,
+    _build_space_and_delta,
+    _compute_batch_metrics,
+)
+from .make_loaders import make_loaders, pad_or_crop
+
+__all__ = ["train", "evaluate", "soft_targets", "pad_or_crop", "make_loaders"]
+
+
+def _resolve_device(config: Config) -> torch.device:
+    if config.device is not None:
+        return torch.device(config.device)
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def train(
+    model: Module,
+    train_dataloader: DataLoader,
+    val_dataloader: Optional[DataLoader],
+    config: Config,
+) -> Dict[str, Optional[float]]:
+    config.validate()
+
+    random.seed(config.seed)
+    np.random.seed(config.seed)
+    torch.manual_seed(config.seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(config.seed)
+    torch.backends.cudnn.benchmark = True
+
+    device = _resolve_device(config)
+    model.to(device)
+
+    if hasattr(model, "seq_len"):
+        if model.seq_len != config.seq_len:
+            raise ValueError("Model seq_len does not match config.seq_len")
+    if hasattr(model, "latent_dim"):
+        if model.latent_dim != config.latent_dim:
+            raise ValueError("Model latent_dim does not match config.latent_dim")
+    if hasattr(model, "n_classes"):
+        if model.n_classes != config.n_classes:
+            raise ValueError("Model n_classes does not match config.n_classes")
+
+    if not isinstance(train_dataloader, DataLoader):
+        raise TypeError("train_dataloader must be an instance of torch.utils.data.DataLoader")
+
+    if val_dataloader is not None and not isinstance(val_dataloader, DataLoader):
+        raise TypeError("val_dataloader must be a DataLoader or None")
+
+    train_loader = train_dataloader
+    val_loader = val_dataloader
+
+    total_train_steps = len(train_loader) * config.epochs
+    if total_train_steps == 0:
+        raise ValueError("Training loader must yield at least one batch per epoch")
+    total_steps = config.total_steps_override or total_train_steps
+
+    centers_hz = torch.tensor(config.centers_hz(), dtype=torch.float32, device=device)
+    space_centers, _ = _build_space_and_delta(centers_hz, config.log_bins)
+
+    optimizer = AdamW(model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
+
+    def lr_lambda(step: int) -> float:
+        if total_steps <= 0:
+            return 1.0
+        if config.warmup_steps > 0 and step < config.warmup_steps:
+            return float(step) / float(max(1, config.warmup_steps))
+        progress = (step - config.warmup_steps) / float(max(1, total_steps - config.warmup_steps))
+        progress = min(max(progress, 0.0), 1.0)
+        return 0.5 * (1.0 + math.cos(math.pi * progress))
+
+    scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda=lr_lambda)
+
+    use_amp = device.type == "cuda" and config.use_amp
+    scaler = torch.cuda.amp.GradScaler(enabled=use_amp)
+
+    global_step = 0
+    best_val_loss = float("inf")
+    best_val_top1 = 0.0
+    best_state: Optional[Dict[str, Tensor]] = None
+
+    for epoch in range(1, config.epochs + 1):
+        model.train()
+        for batch_idx, batch in enumerate(train_loader, start=1):
+            optimizer.zero_grad(set_to_none=True)
+
+            x = batch["x"].to(device, non_blocking=True)
+            freq = batch["freq_hz"].to(device, non_blocking=True)
+            mask = batch["valid_mask"].to(device, non_blocking=True).float()
+
+            with torch.cuda.amp.autocast(enabled=use_amp):
+                logits = model(x)
+                target = soft_targets(freq, centers_hz, config.sigma_bins, config.log_bins)
+                log_q = F.log_softmax(logits, dim=-1)
+                frame_loss = -(target * log_q).sum(dim=-1)
+                mask_sum = mask.sum()
+                if mask_sum <= 0:
+                    continue
+                loss = (frame_loss * mask).sum() / mask_sum
+
+            if use_amp:
+                scaler.scale(loss).backward()
+                scaler.unscale_(optimizer)
+                if config.max_grad_norm is not None and config.max_grad_norm > 0:
+                    torch.nn.utils.clip_grad_norm_(model.parameters(), config.max_grad_norm)
+                scaler.step(optimizer)
+                scaler.update()
+            else:
+                loss.backward()
+                if config.max_grad_norm is not None and config.max_grad_norm > 0:
+                    torch.nn.utils.clip_grad_norm_(model.parameters(), config.max_grad_norm)
+                optimizer.step()
+
+            scheduler.step()
+
+            with torch.no_grad():
+                top1, within, mae = _compute_batch_metrics(
+                    logits, freq, space_centers, config.within_bins, config.log_bins, mask
+                )
+
+            if (global_step + 1) % config.log_interval == 0:
+                current_lr = optimizer.param_groups[0]["lr"]
+                print(
+                    f"Epoch {epoch} Step {global_step + 1}: "
+                    f"lr={current_lr:.6f} loss={loss.item():.4f} "
+                    f"top1={top1.item():.4f} within={within.item():.4f}"
+                )
+
+            should_eval = (global_step + 1) % config.eval_interval == 0
+            if should_eval and val_loader is not None:
+                val_metrics = evaluate(model, val_loader, config)
+                val_loss = val_metrics.get("loss", float("inf"))
+                val_top1 = val_metrics.get("top1", 0.0)
+                print(
+                    f"Validation @ Epoch {epoch} Step {global_step + 1}: "
+                    f"loss={val_loss:.4f} top1={val_top1:.4f} "
+                    f"within={val_metrics.get('within_k', 0.0):.4f} "
+                    f"mae={val_metrics.get('mae_bins', 0.0):.4f}"
+                )
+                if val_loss < best_val_loss:
+                    best_val_loss = val_loss
+                    best_val_top1 = val_top1
+                    best_state = copy.deepcopy({k: v.detach().cpu() for k, v in model.state_dict().items()})
+
+            global_step += 1
+
+        if val_loader is not None:
+            val_metrics = evaluate(model, val_loader, config)
+            val_loss = val_metrics.get("loss", float("inf"))
+            val_top1 = val_metrics.get("top1", 0.0)
+            print(
+                f"Validation @ Epoch {epoch} End: loss={val_loss:.4f} top1={val_top1:.4f} "
+                f"within={val_metrics.get('within_k', 0.0):.4f} mae={val_metrics.get('mae_bins', 0.0):.4f}"
+            )
+            if val_loss < best_val_loss:
+                best_val_loss = val_loss
+                best_val_top1 = val_top1
+                best_state = copy.deepcopy({k: v.detach().cpu() for k, v in model.state_dict().items()})
+
+    if best_state is None and config.save:
+        best_state = copy.deepcopy({k: v.detach().cpu() for k, v in model.state_dict().items()})
+
+    save_path: Optional[str] = None
+    if config.save and best_state is not None:
+        save_path = config.save_file
+        directory = os.path.dirname(save_path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        payload = {
+            "model_state_dict": best_state,
+            "model_class": model.__class__.__name__,
+            "centers_hz": config.centers_hz(),
+            "config_dict": asdict(config),
+        }
+        torch.save(payload, save_path)
+
+    return {
+        "best_val_loss": best_val_loss if best_val_loss != float("inf") else None,
+        "best_val_top1": best_val_top1 if best_val_loss != float("inf") else None,
+        "save_path": save_path,
+    }
+


### PR DESCRIPTION
## Summary
- add a new `pitch_detection_supervised/evaluate.py` module that houses the evaluation helpers and exposes `evaluate` and `soft_targets`
- update `pitch_detection_supervised/train.py` to import the shared helpers from the new module while re-exporting the training API

## Testing
- python -m compileall pitch_detection_supervised/train.py pitch_detection_supervised/evaluate.py pitch_detection_supervised/make_loaders.py

------
https://chatgpt.com/codex/tasks/task_e_68e251d57a588325ba8aff2a1389f148