### PR TITLE
Add RunPod assets for supervised pitch detection

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,6 +33,16 @@ services:
     environment:
       WANDB_API_KEY: ${WANDB_API_KEY}
 
+  pitch_detection_supervised:
+    build:
+      context: ..
+      dockerfile: docker/pitch_detection_supervised/Dockerfile
+    image: gebregl/wavespace-pitch-detection-supervised:v1
+    volumes:
+      - /home/david/mine/projects/wavespace/resources:/resources
+    environment:
+      WANDB_API_KEY: ${WANDB_API_KEY}
+
   pitch_channel_eval:
     build:
       context: ..

--- a/docker/pitch_detection_supervised/Dockerfile
+++ b/docker/pitch_detection_supervised/Dockerfile
@@ -1,0 +1,12 @@
+FROM gebregl/wavespace-dependencies:v2
+WORKDIR /
+
+COPY /docker/pitch_detection_supervised/run_utils.py /run_utils.py
+COPY /docker/pitch_detection_supervised/rp_handler.py /rp_handler.py
+COPY /docker/pitch_detection_supervised/sweep_run.py /sweep_run.py
+COPY /pitch_detection_supervised /pitch_detection_supervised/
+
+COPY /docker/pitch_detection_supervised/test_input.json /test_input.json
+COPY /docker/pitch_detection_supervised/single_run_input.json /single_run_input.json
+
+CMD ["python3", "-u", "rp_handler.py"]

--- a/docker/pitch_detection_supervised/rp_handler.py
+++ b/docker/pitch_detection_supervised/rp_handler.py
@@ -1,0 +1,36 @@
+import json
+import subprocess
+from typing import Any, Dict
+
+import runpod
+
+from pitch_detection_supervised.train import single_run
+
+from run_utils import build_config, instantiate_model, prepare_loaders
+
+
+def handler(event: Dict[str, Any]) -> str:
+    print('Worker Start')
+    payload = event['input']
+
+    if 'sweep_id' in payload:
+        sweep_id = payload['sweep_id']
+        print(f'Runs with sweep id: {sweep_id}')
+        args = ['wandb', 'agent', sweep_id]
+        if 'count' in payload:
+            args.extend(['--count', str(payload['count'])])
+        result = subprocess.run(args, check=False)
+        return f'exit_code {result.returncode}'
+
+    config = build_config(payload)
+    print(f'Single run with configuration: {config}')
+    model = instantiate_model(payload.get('model'), config)
+    train_loader, val_loader = prepare_loaders(payload, config)
+    project = payload.get('project', 'pitch-detection-supervised')
+
+    results = single_run(config=config, model=model, train_loader=train_loader, val_loader=val_loader, project=project)
+    return json.dumps(results)
+
+
+if __name__ == '__main__':
+    runpod.serverless.start({'handler': handler})

--- a/docker/pitch_detection_supervised/run_utils.py
+++ b/docker/pitch_detection_supervised/run_utils.py
@@ -1,0 +1,190 @@
+"""Utilities shared by RunPod entrypoints for supervised pitch detection."""
+from __future__ import annotations
+
+import importlib
+import json
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import torch
+from torch.nn import Module
+from torch.utils.data import DataLoader
+
+from pitch_detection_supervised.configuration import Config
+from pitch_detection_supervised.dilated_tcn import DilatedTCN
+from pitch_detection_supervised.make_loaders import make_loaders
+
+
+Factory = Callable[[Config], Any]
+
+
+def _import_attr(target: str) -> Callable[..., Any]:
+    module_name, _, attribute_name = target.rpartition('.')
+    if not module_name or not attribute_name:
+        raise ValueError(f"Invalid import target '{target}'. Expected format 'module.attr'.")
+    module = importlib.import_module(module_name)
+    try:
+        return getattr(module, attribute_name)
+    except AttributeError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Attribute '{attribute_name}' not found in module '{module_name}'.") from exc
+
+
+def _call_factory(factory: Callable[..., Any], config: Config, params: Dict[str, Any]) -> Any:
+    """Call *factory* passing ``config`` when supported."""
+
+    try:
+        return factory(config=config, **params)
+    except TypeError as exc:
+        first_error = exc
+    else:  # pragma: no cover - sanity guard
+        raise AssertionError('factory invocation unexpectedly succeeded twice')
+
+    try:
+        return factory(config, **params)
+    except TypeError:
+        pass
+
+    try:
+        return factory(**params)
+    except TypeError as exc:
+        message = (
+            f"Unable to call factory '{factory}' with provided parameters. "
+            f"Last error: {exc} (first error: {first_error})"
+        )
+        raise TypeError(message) from exc
+
+
+def build_config(payload: Dict[str, Any]) -> Config:
+    """Construct a :class:`Config` from the request payload."""
+
+    config_dict = payload.get('config')
+    if config_dict is None:
+        config_dict = payload
+    if not isinstance(config_dict, dict):
+        raise TypeError("'config' must be a dictionary when provided.")
+    return Config.from_dict(config_dict)
+
+
+def instantiate_model(spec: Optional[Any], config: Config) -> Module:
+    """Create the model described by *spec* or a default ``DilatedTCN``."""
+
+    if spec is None:
+        return DilatedTCN(
+            n_classes=config.n_classes,
+            seq_len=config.seq_len,
+            latent_dim=config.latent_dim,
+        )
+
+    target: Optional[str]
+    params: Dict[str, Any]
+    if isinstance(spec, str):
+        target = spec
+        params = {}
+    elif isinstance(spec, dict):
+        target = spec.get('target')
+        if not isinstance(target, str):
+            raise ValueError("Model specification dictionary must contain a 'target' string.")
+        params = dict(spec.get('params', {}))
+    else:
+        raise TypeError('Model specification must be a string, dict, or null.')
+
+    factory = _import_attr(target)
+    result = _call_factory(factory, config, params)
+    if not isinstance(result, Module):
+        raise TypeError('Model factory must return an instance of torch.nn.Module.')
+    return result
+
+
+def load_dataset_from_path(path_str: str) -> Any:
+    """Load a dataset iterable from *path_str* supporting ``.pt``/``.pth`` and JSON files."""
+
+    path = Path(path_str)
+    if not path.exists():
+        raise FileNotFoundError(f"Dataset path '{path}' does not exist.")
+
+    suffix = path.suffix.lower()
+    if suffix in {'.pt', '.pth'}:
+        return torch.load(path, map_location='cpu')
+    if suffix == '.json':
+        with path.open('r', encoding='utf-8') as file:
+            return json.load(file)
+    if suffix in {'.jsonl', '.ndjson'}:
+        with path.open('r', encoding='utf-8') as file:
+            return [json.loads(line) for line in file if line.strip()]
+
+    raise ValueError(f"Unsupported dataset file extension '{suffix}' for path '{path}'.")
+
+
+def _resolve_dataset(payload: Dict[str, Any], prefix: str) -> Optional[Any]:
+    value = payload.get(prefix)
+    if value is None:
+        path_key = f'{prefix}_path'
+        value = payload.get(path_key)
+    if value is None:
+        return None
+
+    if isinstance(value, str):
+        return load_dataset_from_path(value)
+    if isinstance(value, dict):
+        if 'path' in value:
+            return load_dataset_from_path(value['path'])
+        if 'data_path' in value:
+            return load_dataset_from_path(value['data_path'])
+        if 'data' in value:
+            return value['data']
+    raise TypeError(f"Unsupported dataset specification for '{prefix}'.")
+
+
+def _instantiate_loader(spec: Optional[Any], config: Config) -> Optional[DataLoader]:
+    if spec is None:
+        return None
+
+    target: Optional[str]
+    params: Dict[str, Any]
+    if isinstance(spec, str):
+        target = spec
+        params = {}
+    elif isinstance(spec, dict):
+        target = spec.get('target')
+        if not isinstance(target, str):
+            raise ValueError("Loader specification dictionary must contain a 'target' string.")
+        params = dict(spec.get('params', {}))
+    else:
+        raise TypeError('Loader specification must be a string, dict, or null.')
+
+    factory = _import_attr(target)
+    result = _call_factory(factory, config, params)
+    if result is None:
+        return None
+    if isinstance(result, DataLoader):
+        return result
+    raise TypeError('Loader factory must return a torch.utils.data.DataLoader or None.')
+
+
+def prepare_loaders(payload: Dict[str, Any], config: Config) -> Tuple[DataLoader, Optional[DataLoader]]:
+    """Create training and validation loaders from the payload."""
+
+    train_loader = _instantiate_loader(payload.get('train_loader'), config)
+    val_loader = _instantiate_loader(payload.get('val_loader'), config)
+
+    if train_loader is not None:
+        return train_loader, val_loader
+
+    train_data = _resolve_dataset(payload, 'train_data')
+    if train_data is None:
+        raise ValueError("Request must provide either 'train_loader' or 'train_data'.")
+
+    val_data = _resolve_dataset(payload, 'val_data')
+    loader_config = payload.get('loader_config')
+    if loader_config is not None:
+        if not isinstance(loader_config, dict):
+            raise TypeError("'loader_config' must be a dictionary when provided.")
+        config = replace(config, **{k: v for k, v in loader_config.items() if hasattr(config, k)})
+
+    train_loader, derived_val_loader = make_loaders(train_data, val_data, config)
+    if train_loader is None:
+        raise RuntimeError('Loader creation returned None for training data.')
+    if val_loader is None:
+        val_loader = derived_val_loader
+    return train_loader, val_loader

--- a/docker/pitch_detection_supervised/single_run_input.json
+++ b/docker/pitch_detection_supervised/single_run_input.json
@@ -1,0 +1,19 @@
+{
+  "input": {
+    "config": {
+      "batch_size": 32,
+      "epochs": 5,
+      "latent_dim": 128,
+      "seq_len": 75
+    },
+    "train_data_path": "/runpod-volume/pitch_supervised_train.pt",
+    "val_data_path": "/runpod-volume/pitch_supervised_val.pt",
+    "model": {
+      "target": "pitch_detection_supervised.dilated_tcn.DilatedTCN",
+      "params": {
+        "hidden_dim": 256,
+        "use_third_block": true
+      }
+    }
+  }
+}

--- a/docker/pitch_detection_supervised/sweep_run.py
+++ b/docker/pitch_detection_supervised/sweep_run.py
@@ -1,0 +1,77 @@
+import json
+import os
+from functools import lru_cache
+from typing import Any, Dict, Optional
+
+from pitch_detection_supervised.configuration import Config
+from pitch_detection_supervised.make_loaders import make_loaders
+from pitch_detection_supervised.train import sweep_run as run_sweep
+
+from run_utils import instantiate_model, load_dataset_from_path
+
+
+@lru_cache(maxsize=None)
+def _load_dataset(path: str) -> Any:
+    return load_dataset_from_path(path)
+
+
+def _train_loader_factory(config: Config):
+    train_path = os.environ.get('PITCH_SUP_TRAIN_DATA_PATH')
+    if not train_path:
+        raise RuntimeError('PITCH_SUP_TRAIN_DATA_PATH environment variable must be set.')
+    train_data = _load_dataset(train_path)
+    val_path = os.environ.get('PITCH_SUP_VAL_DATA_PATH')
+    val_data = _load_dataset(val_path) if val_path else None
+    train_loader, _ = make_loaders(train_data, val_data, config)
+    if train_loader is None:
+        raise RuntimeError('make_loaders returned None for training data.')
+    return train_loader
+
+
+def _val_loader_factory(config: Config):
+    val_path = os.environ.get('PITCH_SUP_VAL_DATA_PATH')
+    if not val_path:
+        return None
+    val_data = _load_dataset(val_path)
+    _, val_loader = make_loaders(None, val_data, config)
+    return val_loader
+
+
+def _model_factory(config: Config):
+    spec_json = os.environ.get('PITCH_SUP_MODEL_SPEC')
+    spec: Optional[Any]
+    if spec_json:
+        loaded = json.loads(spec_json)
+        if not isinstance(loaded, (dict, str)) and loaded is not None:
+            raise TypeError('PITCH_SUP_MODEL_SPEC must encode a string or dictionary.')
+        spec = loaded
+    else:
+        spec = None
+    return instantiate_model(spec, config)
+
+
+def _base_config() -> Optional[Config]:
+    base_json = os.environ.get('PITCH_SUP_BASE_CONFIG')
+    if not base_json:
+        return None
+    data = json.loads(base_json)
+    if not isinstance(data, dict):
+        raise TypeError('PITCH_SUP_BASE_CONFIG must encode a dictionary.')
+    return Config.from_dict(data)
+
+
+def main() -> None:
+    base_config = _base_config()
+    val_factory = _val_loader_factory if os.environ.get('PITCH_SUP_VAL_DATA_PATH') else None
+    project = os.environ.get('PITCH_SUP_PROJECT', 'pitch-detection-supervised')
+    run_sweep(
+        model_factory=_model_factory,
+        train_loader_factory=_train_loader_factory,
+        val_loader_factory=val_factory,
+        base_config=base_config,
+        project=project,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/docker/pitch_detection_supervised/test_input.json
+++ b/docker/pitch_detection_supervised/test_input.json
@@ -1,0 +1,5 @@
+{
+  "input": {
+    "sweep_id": "david-moser-ggg/pitch-detection-supervised/example"
+  }
+}


### PR DESCRIPTION
## Summary
- add a RunPod handler for pitch_detection_supervised that instantiates models and loaders from request payloads
- share helper utilities to build configs, resolve datasets, and instantiate resources
- add a sweep entrypoint, Dockerfile, and example RunPod payloads for supervised pitch detection
- register the supervised pitch detection image in docker-compose

## Testing
- python -m compileall docker/pitch_detection_supervised

------
https://chatgpt.com/codex/tasks/task_e_68e3f46da01c8325910f60d4ff9c300c